### PR TITLE
Updating AlarmManager.Java to remove crash

### DIFF
--- a/AlarmClock/src/com/trigg/alarmclock/AlarmManagerHelper.java
+++ b/AlarmClock/src/com/trigg/alarmclock/AlarmManagerHelper.java
@@ -29,7 +29,8 @@ public class AlarmManagerHelper extends BroadcastReceiver {
 		AlarmDBHelper dbHelper = new AlarmDBHelper(context);
 
 		List<AlarmModel> alarms =  dbHelper.getAlarms();
-		
+		if(alarms!=null)
+		{
 		for (AlarmModel alarm : alarms) {
 			if (alarm.isEnabled) {
 
@@ -74,6 +75,8 @@ public class AlarmManagerHelper extends BroadcastReceiver {
 				}
 			}
 		}
+		
+	        }
 	}
 	
 	@SuppressLint("NewApi")


### PR DESCRIPTION
When there is no alarm listed in the database and the device is restarted, the AlarmManagerHelper tries to set alarm. As alarms object is empty then it creates a null pointer exception. So, we check for if alarms is null. if not then we set alarm.